### PR TITLE
use ThreadSafe::Cache instead of custom mutex

### DIFF
--- a/lib/sse_rails_engine/connection.rb
+++ b/lib/sse_rails_engine/connection.rb
@@ -9,7 +9,6 @@ module SseRailsEngine
                   "\r\n"].join.freeze
 
     def initialize(io, env)
-      clear_active_db_connections
       @socket = io
       @socket.write SSE_HEADER
       @socket.flush
@@ -32,11 +31,6 @@ module SseRailsEngine
 
     def requested_channels(env)
       Rack::Utils.parse_query(env['QUERY_STRING']).fetch('channels', []).split(',').flatten
-    end
-
-    def clear_active_db_connections
-      return unless defined? ActiveRecord::Base.clear_active_connections!
-      ActiveRecord::Base.clear_active_connections!
     end
   end
 end

--- a/lib/sse_rails_engine/manager.rb
+++ b/lib/sse_rails_engine/manager.rb
@@ -37,12 +37,14 @@ module SseRailsEngine
     end
 
     def send_event(name, data = '')
-      @connections.each_pair do |stream, connection|
-        begin
-          connection.write(name, data)
-        rescue => ex
-          Rails.logger.debug "SSE Client disconnected: #{stream} - #{ex.message}"
-          close_connection(stream)
+      @mutex.synchronize do
+        @connections.each_pair do |stream, connection|
+          begin
+            connection.write(name, data)
+          rescue => ex
+            Rails.logger.debug "SSE Client disconnected: #{stream} - #{ex.message}"
+            close_connection(stream)
+          end
         end
       end
     end


### PR DESCRIPTION
ActiveSupport comes with ThreadSafe::Cache which, in the case of MRI, only locks on writes.
This should prevent incoming connections from being blocked while events are being sent to existing connections.

This is a stab in the dark, but 40% of the time in production is spent inside `futex` calls.

@henders 