### PR TITLE
allow specifying an access-control-allow-origin

### DIFF
--- a/config/initializers/headers.rb
+++ b/config/initializers/headers.rb
@@ -1,14 +1,14 @@
 headers = [
-  "HTTP/1.1 200 OK",
-  "Content-Type: text/event-stream",
-  "Cache-Control: no-cache, no-store",
-  "Connection: close"
+  'HTTP/1.1 200 OK',
+  'Content-Type: text/event-stream',
+  'Cache-Control: no-cache, no-store',
+  'Connection: close'
 ]
 
 if origin = SseRailsEngine.access_control_allow_origin
   headers << "Access-Control-Allow-Origin: #{origin}"
 end
 
-headers << "" << ""
+headers << '' << ''
 
 SseRailsEngine::Connection.sse_header = headers.join("\r\n").freeze

--- a/config/initializers/headers.rb
+++ b/config/initializers/headers.rb
@@ -5,9 +5,8 @@ headers = [
   'Connection: close'
 ]
 
-if origin = SseRailsEngine.access_control_allow_origin
-  headers << "Access-Control-Allow-Origin: #{origin}"
-end
+origin = SseRailsEngine.access_control_allow_origin
+headers << "Access-Control-Allow-Origin: #{origin}" if origin
 
 headers << '' << ''
 

--- a/config/initializers/headers.rb
+++ b/config/initializers/headers.rb
@@ -1,0 +1,14 @@
+headers = [
+  "HTTP/1.1 200 OK",
+  "Content-Type: text/event-stream",
+  "Cache-Control: no-cache, no-store",
+  "Connection: close"
+]
+
+if origin = SseRailsEngine.access_control_allow_origin
+  headers << "Access-Control-Allow-Origin: #{origin}"
+end
+
+headers << "" << ""
+
+SseRailsEngine::Connection.sse_header = headers.join("\r\n").freeze

--- a/config/initializers/sse_rails_engine.rb
+++ b/config/initializers/sse_rails_engine.rb
@@ -1,2 +1,1 @@
-
 Rails.configuration.middleware.delete 'Rack::Lock'

--- a/lib/sse-rails-engine.rb
+++ b/lib/sse-rails-engine.rb
@@ -3,9 +3,9 @@ require 'sse_rails_engine/connection'
 require 'sse_rails_engine/manager'
 
 module SseRailsEngine
-  mattr_accessor :heartbeat_interval
+  mattr_accessor :heartbeat_interval, :access_control_allow_origin
 
-  @@heartbeat_interval = 5.seconds
+  self.heartbeat_interval = 5.seconds
 
   def self.manager
     @manager ||= Manager.new

--- a/lib/sse_rails_engine/connection.rb
+++ b/lib/sse_rails_engine/connection.rb
@@ -1,16 +1,11 @@
 module SseRailsEngine
   class Connection
     attr_accessor :stream, :channels
-
-    SSE_HEADER = ["HTTP/1.1 200 OK\r\n",
-                  "Content-Type: text/event-stream\r\n",
-                  "Cache-Control: no-cache, no-store\r\n",
-                  "Connection: close\r\n",
-                  "\r\n"].join.freeze
+    cattr_accessor :sse_header
 
     def initialize(io, env)
       @socket = io
-      @socket.write SSE_HEADER
+      @socket.write(sse_header)
       @socket.flush
       @stream = ActionController::Live::SSE.new(io)
       @channels = requested_channels(env)
@@ -26,7 +21,7 @@ module SseRailsEngine
 
     def filtered?(channel)
       return false if @channels.empty? || channel == Manager::HEARTBEAT_EVENT
-      !@channels.include? channel
+      !@channels.include?(channel)
     end
 
     def requested_channels(env)

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -11,6 +11,8 @@ require "rails/test_unit/railtie"
 Bundler.require(*Rails.groups)
 require "sse-rails-engine"
 
+SseRailsEngine.access_control_allow_origin = 'https://example.org'
+
 module Dummy
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -26,4 +28,3 @@ module Dummy
     # config.i18n.default_locale = :de
   end
 end
-

--- a/test/lib/sse-rails-engine_test.rb
+++ b/test/lib/sse-rails-engine_test.rb
@@ -27,11 +27,16 @@ describe SseRailsEngine do
     SseRailsEngine.setup do |config|
       config.heartbeat_interval = 1.minute
     end
+
     SseRailsEngine.heartbeat_interval.must_equal 1.minute
   end
 
   it 'calls shortcut module function' do
     SseRailsEngine.manager.expects(:send_event).once
     SseRailsEngine.send_event('name', 'foo')
+  end
+
+  it 'adds an access-control-allow-origin header' do
+    SseRailsEngine::Connection.sse_header.must_include('Access-Control-Allow-Origin: https://example.org')
   end
 end

--- a/test/lib/sse_rails_engine/manager_test.rb
+++ b/test/lib/sse_rails_engine/manager_test.rb
@@ -46,14 +46,14 @@ describe SseRailsEngine::Manager do
   it 'writes string event to stream' do
     manager.register(env1)
     manager.send_event('foo', 'bar')
-    env1['rack.hijack_io'].string.must_equal(SseRailsEngine::Connection::SSE_HEADER + "event: foo\ndata: bar\n\n")
+    env1['rack.hijack_io'].string.must_equal(SseRailsEngine::Connection.sse_header + "event: foo\ndata: bar\n\n")
   end
 
   it 'writes event object to stream' do
     manager.register(env1)
     manager.send_event('foo', a: 123, 'b' => 'abc', c: { foo: 'bar' })
     env1['rack.hijack_io'].string.must_equal(
-      SseRailsEngine::Connection::SSE_HEADER +
+      SseRailsEngine::Connection.sse_header +
       "event: foo\ndata: {\"a\":123,\"b\":\"abc\",\"c\":{\"foo\":\"bar\"}}\n\n"
     )
   end
@@ -75,7 +75,7 @@ describe SseRailsEngine::Manager do
     manager.register(env1)
     manager.send_event('foo')
     env1['rack.hijack_io'].string.must_equal(
-      SseRailsEngine::Connection::SSE_HEADER + "event: foo\ndata: \n\n", 'env1 should have received event')
+      SseRailsEngine::Connection.sse_header + "event: foo\ndata: \n\n", 'env1 should have received event')
   end
 
   it 'does not send events to clients that didnt register for them' do
@@ -83,7 +83,7 @@ describe SseRailsEngine::Manager do
     manager.register(env1)
     manager.send_event('test')
     env1['rack.hijack_io'].string.must_equal(
-      SseRailsEngine::Connection::SSE_HEADER, 'env2 should not have received event')
+      SseRailsEngine::Connection.sse_header, 'env2 should not have received event')
   end
 
   it 'filters msgs depending on channels requested' do
@@ -92,8 +92,8 @@ describe SseRailsEngine::Manager do
     manager.register(env2)
     manager.send_event('test')
     env1['rack.hijack_io'].string.must_equal(
-      SseRailsEngine::Connection::SSE_HEADER + "event: test\ndata: \n\n", 'env1 should have received event')
+      SseRailsEngine::Connection.sse_header + "event: test\ndata: \n\n", 'env1 should have received event')
     env2['rack.hijack_io'].string.must_equal(
-      SseRailsEngine::Connection::SSE_HEADER, 'env2 should not have received event')
+      SseRailsEngine::Connection.sse_header, 'env2 should not have received event')
   end
 end


### PR DESCRIPTION
Since Chrome has a 6 socket per domain limit, if you have multiple SSE connections on each page you can only a certain number of pages open.

@zendesk/samson @henders 

For https://github.com/zendesk/samson/pull/586