### PR TITLE
Lazy threading

### DIFF
--- a/lib/sse_rails_engine/manager.rb
+++ b/lib/sse_rails_engine/manager.rb
@@ -65,21 +65,21 @@ module SseRailsEngine
     private
 
     def close_connection(stream)
-      if connection = @connections[stream]
+      if connection = @connections.delete(stream)
         connection.stream.close
       end
-      @connections.delete(stream)
     end
 
     def start_heartbeats
       @heartbeat_thread ||= Thread.new do
-        Rails.logger.debug 'Starting SSE heartbeat thread!'
+        Rails.logger.debug 'Starting SSE heartbeat thread'
         loop do
           sleep SseRailsEngine.heartbeat_interval
           send_event(HEARTBEAT_EVENT)
           break unless @connections.present?
         end
 
+        Rails.logger.debug 'Terminating SSE heartbeat thread'
         @heartbeat_thread = nil
       end
     end

--- a/lib/sse_rails_engine/version.rb
+++ b/lib/sse_rails_engine/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SseRailsEngine
-  VERSION = '1.7.0'
+  VERSION = '1.8.0'
 end


### PR DESCRIPTION
Neat implementation of SSE. This adds a little housekeeping, including:

- `close_connection` always deletes the given stream. Previously, a broken reference would return early and the stream would never get released.

- Adjusts the heartbeat thread to be lazily instantiated, and then to release itself when not being used. This is done by activating the heartbeat when a connection is opened, and then exiting the thread after a loop finishes with no connected streams.